### PR TITLE
feat/add endpoint to send PIN via SMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+app/static/firebase_config.json

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,34 @@
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+from flask_session import Session
+from .config import Config
+from .routes import api
+import logging
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+
+    CORS(app, supports_credentials=True, resources={r"/*": {"origins": Config.CORS_ORIGINS}})
+    Session(app)
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    app.register_blueprint(api, url_prefix='/')
+
+    @app.errorhandler(Exception)
+    def handle_exception(e):
+        logger.error("An error occurred: %s", str(e), exc_info=True)
+        return jsonify({"error": "Internal Error"}), 500
+
+    @app.before_request
+    def before_request():
+        logger.info("Request: %s %s", request.method, request.url)
+
+    @app.after_request
+    def after_request(response):
+        logger.info("Response: %s", response.status_code)
+        return response
+
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,31 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class Config:
+    TWILIO_ACCOUNT_SID = os.getenv('TWILIO_ACCOUNT_SID')
+    TWILIO_AUTH_TOKEN = os.getenv('TWILIO_AUTH_TOKEN')
+    TWILIO_PHONE_NUMBER = os.getenv('TWILIO_PHONE_NUMBER')
+    FIREBASE_CREDENTIALS = os.getenv('FIREBASE_CREDENTIALS')
+    CORS_ORIGINS = os.getenv('CORS_ORIGINS', 'http://localhost:5173')
+    SECRET_KEY = os.getenv('SECRET_KEY')
+    SESSION_TYPE = 'filesystem'
+    SESSION_COOKIE_SECURE = True
+    SESSION_COOKIE_SAMESITE = 'None'
+    SESSION_COOKIE_HTTPONLY = True
+
+    @classmethod
+    def validate(cls):
+        required_vars = [
+            'TWILIO_ACCOUNT_SID',
+            'TWILIO_AUTH_TOKEN',
+            'TWILIO_PHONE_NUMBER',
+            'FIREBASE_CREDENTIALS',
+            'SECRET_KEY'
+        ]
+        for var in required_vars:
+            if not getattr(cls, var):
+                raise ValueError(f"Environment variable {var} is missing")
+
+Config.validate()

--- a/app/firebase.py
+++ b/app/firebase.py
@@ -1,0 +1,7 @@
+import firebase_admin
+from firebase_admin import credentials, firestore
+from .config import Config
+
+cred = credentials.Certificate(Config.FIREBASE_CREDENTIALS)
+firebase_admin.initialize_app(cred)
+db = firestore.client()

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,71 @@
+from flask import Blueprint, request, jsonify, session
+from .firebase import db
+from .twilio_client import client
+import random
+from datetime import datetime
+from .config import Config
+import logging
+
+api = Blueprint('api', __name__)
+logger = logging.getLogger(__name__)
+
+@api.route('/health', methods=['GET'])
+def health():
+    return jsonify({'status': 'ok'}), 200
+
+@api.route('/send_pin', methods=['POST'])
+def send_pin():
+    data = request.json
+    phone = data.get('phone')
+
+    if not phone:
+        return jsonify({"mensaje": "Número de teléfono no proporcionado", "resultado": False}), 400
+
+    pin = random.randint(1000, 9999)
+    db.collection('verifications').document(phone).set({
+        'pin': pin,
+        'timestamp': datetime.now()
+    })
+
+    try:
+        message = client.messages.create(
+            body=f'Su código de verificación es {pin}',
+            from_=Config.TWILIO_PHONE_NUMBER,
+            to=phone
+        )
+        return jsonify({"mensaje": "PIN enviado exitosamente", "resultado": True})
+    except Exception as e:
+        logger.error("Error al enviar PIN: %s", str(e), exc_info=True)
+        return jsonify({"mensaje": "Error al enviar PIN", "resultado": False}), 500
+
+@api.route('/register', methods=['POST'])
+def register():
+    data = request.json
+    phone = data.get('phone')
+    pin = data.get('pin')
+
+    if not phone or not pin:
+        return jsonify({"mensaje": "Número de teléfono o PIN no proporcionado", "resultado": False}), 400
+
+    doc_ref = db.collection('verifications').document(phone)
+    doc = doc_ref.get()
+
+    if doc.exists:
+        stored_pin = doc.to_dict().get('pin')
+        if int(pin) == stored_pin:
+            user_ref = db.collection('users').document(phone)
+            user_ref.set({
+                'phone': phone,
+                'registered': True
+            })
+            session['user'] = phone
+            return jsonify({"mensaje": "Usuario registrado exitosamente", "resultado": True})
+        else:
+            return jsonify({"mensaje": "PIN incorrecto. Inténtalo de nuevo.", "resultado": False}), 401
+    else:
+        return jsonify({"mensaje": "No se encontró un PIN para este número de teléfono.", "resultado": False}), 404
+
+@api.route('/logout', methods=['GET'])
+def logout():
+    session.pop('user', None)
+    return jsonify({"mensaje": "Sesión Cerrada", "resultado": True})

--- a/app/twilio_client.py
+++ b/app/twilio_client.py
@@ -1,0 +1,4 @@
+from twilio.rest import Client
+from .config import Config
+
+client = Client(Config.TWILIO_ACCOUNT_SID, Config.TWILIO_AUTH_TOKEN)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,15 @@
+import random
+
+def generate_pin():
+    return random.randint(1000, 9999)
+
+def send_pin(phone, pin):
+    # Implementa la lógica para enviar el PIN al número de teléfono.
+    print(f"Sending PIN {pin} to phone {phone}")
+
+def format_phone_number(phone, country_code="+52"):
+    # Asegurarse de que el número de teléfono no tenga espacios ni guiones y que comience con el código del país
+    phone = phone.replace(" ", "").replace("-", "")
+    if not phone.startswith(country_code):
+        phone = country_code + phone
+    return phone

--- a/run.py
+++ b/run.py
@@ -1,0 +1,5 @@
+from app import create_app
+
+app = create_app()
+if __name__ == '__main__':
+    app.run(debug=True, use_reloader=False)


### PR DESCRIPTION
**Motivation**
Add a new endpoint to send a PIN via SMS using Twilio to validate user login or registration.

**Contrast with Previous Behavior**
Previously, there was no way to send a validation PIN via SMS. This change adds this functionality, improving the authentication flow.

**Tested**
Tested in Postman
Local Environment